### PR TITLE
Update Python base image to version 3.13-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3.13-slim
 
 # Install system dependencies for Rust and UV
 RUN apt update && apt install -y \


### PR DESCRIPTION
Set python version to 3.13 which is the newest version of python that docker build runs successfully. Can confirm python 3.14 is not currently compatible without modifying the code base.